### PR TITLE
feat: add aggressive cache headers

### DIFF
--- a/serve.json
+++ b/serve.json
@@ -3,5 +3,21 @@
   "trailingSlash": false,
   "rewrites": [
     { "source": "/certification/**", "destination": "/certification/index.html" }
+  ],
+  "headers": [
+    {
+      "source" : "**/*.@(js|css|woff)",
+      "headers" : [{
+        "key" : "Cache-Control",
+        "value" : "public, max-age=31536000, immutable"
+      }]
+    },
+    {
+      "source" : "**/sass.sync.js",
+      "headers" : [{
+        "key" : "Cache-Control",
+        "value" : "no-cache"
+      }]
+    }
   ]
 }

--- a/serve.json
+++ b/serve.json
@@ -6,7 +6,7 @@
   ],
   "headers": [
     {
-      "source" : "**/*.@(js|css|woff)",
+      "source" : "**/*.@(js|css|woff|png|ttf)",
       "headers" : [{
         "key" : "Cache-Control",
         "value" : "public, max-age=31536000, immutable"


### PR DESCRIPTION
Everything except bootstrap.css and sass.sync.js gets content hashes
and so can be cached indefinitely.

bootstrap.css we never update and are intending to remove, so I did not
create an exception for it.

sass.sync.js is probably never getting updated, but I created an
exception just in case.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

https://github.com/freeCodeCamp/freeCodeCamp/pull/42097 should be merged first, so that we're generating hashes for everything except the two exceptions noted here, but it's not crucial.

<!-- Feel free to add any additional description of changes below this line -->
