### PR TITLE
feat: redirect to new curriculum paths

### DIFF
--- a/serve.json
+++ b/serve.json
@@ -5,6 +5,19 @@
     { "source": "/certification/**", "destination": "/certification/index.html" }
   ],
   "redirects": [
+    { "source": "/challenges", "destination": "/learn" },
+    {
+      "source": "/challenges/:superblock",
+      "destination": "/learn/:superblock"
+    },
+    {
+      "source": "/challenges/:superblock/:block",
+      "destination": "/learn/:superblock/:block"
+    },
+    {
+      "source": "/challenges/:superblock/:block/:challenge",
+      "destination": "/learn/:superblock/:block/:challenge"
+    },
     {
       "source": "/learn/apis-and-microservices",
       "destination": "/learn/back-end-development-and-apis"

--- a/serve.json
+++ b/serve.json
@@ -5,62 +5,37 @@
     { "source": "/certification/**", "destination": "/certification/index.html" }
   ],
   "redirects": [
-    { "source": "/challenges", "destination": "/learn" },
     {
-      "source": "/challenges/:superblock",
-      "destination": "/learn/:superblock"
-    },
-    {
-      "source": "/challenges/:superblock/:block",
-      "destination": "/learn/:superblock/:block"
-    },
-    {
-      "source": "/challenges/:superblock/:block/:challenge",
-      "destination": "/learn/:superblock/:block/:challenge"
-    },
-    {
-      "source": "/learn/apis-and-microservices",
-      "destination": "/learn/back-end-development-and-apis"
+      "source": "/challenges/:superblock?/:block?/:challenge?",
+      "destination": "/learn/:superblock?/:block?/:challenge?"
     },
     {
       "source": "/learn/apis-and-microservices/apis-and-microservices-projects",
       "destination": "/learn/back-end-development-and-apis/back-end-development-and-apis-projects"
     },
     {
-      "source": "/learn/apis-and-microservices/:block",
-      "destination": "/learn/back-end-development-and-apis/:block"
-    },
-    {
       "source": "/learn/apis-and-microservices/apis-and-microservices-projects/:challenge",
       "destination": "/learn/back-end-development-and-apis/back-end-development-and-apis-projects/:challenge"
     },
     {
-      "source": "/learn/apis-and-microservices/:block/:challenge",
-      "destination": "/learn/back-end-development-and-apis/:block/:challenge"
+      "source": "/learn/apis-and-microservices/:block?/:challenge?",
+      "destination": "/learn/back-end-development-and-apis/:block?/:challenge?"
     },
     {
       "source": "/certification/:username/apis-and-microservices",
       "destination": "/certification/:username/back-end-development-and-apis"
     },
     {
-      "source": "/learn/front-end-libraries",
-      "destination": "/learn/front-end-development-libraries"
-    },
-    {
       "source": "/learn/front-end-libraries/front-end-libraries-projects",
       "destination": "/learn/front-end-development-libraries/front-end-development-libraries-projects"
-    },
-    {
-      "source": "/learn/front-end-libraries/:block",
-      "destination": "/learn/front-end-development-libraries/:block"
     },
     {
       "source": "/learn/front-end-libraries/front-end-libraries-projects/:challenge",
       "destination": "/learn/front-end-development-libraries/front-end-development-libraries-projects/:challenge"
     },
     {
-      "source": "/learn/front-end-libraries/:block/:challenge",
-      "destination": "/learn/front-end-development-libraries/:block/:challenge"
+      "source": "/learn/front-end-libraries/:block?/:challenge?",
+      "destination": "/learn/front-end-development-libraries/:block?/:challenge?"
     },
     {
       "source": "/certification/:username/front-end-libraries",

--- a/serve.json
+++ b/serve.json
@@ -3,5 +3,55 @@
   "trailingSlash": false,
   "rewrites": [
     { "source": "/certification/**", "destination": "/certification/index.html" }
+  ],
+  "redirects": [
+    {
+      "source": "/learn/apis-and-microservices",
+      "destination": "/learn/back-end-development-and-apis"
+    },
+    {
+      "source": "/learn/apis-and-microservices/apis-and-microservices-projects",
+      "destination": "/learn/back-end-development-and-apis/back-end-development-and-apis-projects"
+    },
+    {
+      "source": "/learn/apis-and-microservices/:block",
+      "destination": "/learn/back-end-development-and-apis/:block"
+    },
+    {
+      "source": "/learn/apis-and-microservices/apis-and-microservices-projects/:challenge",
+      "destination": "/learn/back-end-development-and-apis/back-end-development-and-apis-projects/:challenge"
+    },
+    {
+      "source": "/learn/apis-and-microservices/:block/:challenge",
+      "destination": "/learn/back-end-development-and-apis/:block/:challenge"
+    },
+    {
+      "source": "/certification/:username/apis-and-microservices",
+      "destination": "/certification/:username/back-end-development-and-apis"
+    },
+    {
+      "source": "/learn/front-end-libraries",
+      "destination": "/learn/front-end-development-libraries"
+    },
+    {
+      "source": "/learn/front-end-libraries/front-end-libraries-projects",
+      "destination": "/learn/front-end-development-libraries/front-end-development-libraries-projects"
+    },
+    {
+      "source": "/learn/front-end-libraries/:block",
+      "destination": "/learn/front-end-development-libraries/:block"
+    },
+    {
+      "source": "/learn/front-end-libraries/front-end-libraries-projects/:challenge",
+      "destination": "/learn/front-end-development-libraries/front-end-development-libraries-projects/:challenge"
+    },
+    {
+      "source": "/learn/front-end-libraries/:block/:challenge",
+      "destination": "/learn/front-end-development-libraries/:block/:challenge"
+    },
+    {
+      "source": "/certification/:username/front-end-libraries",
+      "destination": "/certification/:username/front-end-development-libraries"
+    }
   ]
 }


### PR DESCRIPTION
The order of redirects matters - the specific urls (without "routing segments" like :block) must come before the more general urls.
