### PR TITLE
feat: add cache-control headers

### DIFF
--- a/serve.json
+++ b/serve.json
@@ -2,25 +2,7 @@
   "directoryListing": false,
   "headers": [
     {
-      "source": "**/*.html",
-      "headers": [
-        {
-          "key": "Cache-Control",
-          "value": "public, max-age=0, must-revalidate"
-        }
-      ]
-    },
-    {
-      "source": "**/app-data.json",
-      "headers": [
-        {
-          "key": "Cache-Control",
-          "value": "public, max-age=0, must-revalidate"
-        }
-      ]
-    },
-    {
-      "source": "**/page-data.json",
+      "source": "{**/*.html,**/app-data.json, **/page-data.json}",
       "headers": [
         {
           "key": "Cache-Control",

--- a/serve.json
+++ b/serve.json
@@ -2,7 +2,7 @@
   "directoryListing": false,
   "headers": [
     {
-      "source": "{**/*.html,**/app-data.json, **/page-data.json}",
+      "source": "{**/*.html,**/app-data.json,**/page-data.json}",
       "headers": [
         {
           "key": "Cache-Control",
@@ -20,7 +20,7 @@
       ]
     },
     {
-      "source": "{misc/*.js, sw.js, css/bootstrap.min.css}",
+      "source": "{misc/*.js,sw.js,css/bootstrap.min.css}",
       "headers": [
         {
           "key": "Cache-Control",

--- a/serve.json
+++ b/serve.json
@@ -20,7 +20,7 @@
       ]
     },
     {
-      "source": "{misc/*.js, sw.js}",
+      "source": "{misc/*.js, sw.js, css/bootstrap.min.css}",
       "headers": [
         {
           "key": "Cache-Control",

--- a/serve.json
+++ b/serve.json
@@ -1,5 +1,34 @@
 {
   "directoryListing": false,
+  "headers": [
+    {
+      "source": "**/*.html",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "**/app-data.json",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "**/page-data.json",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
+        }
+      ]
+    }
+  ],
   "trailingSlash": false,
   "rewrites": [
     { "source": "/certification/**", "destination": "/certification/index.html" }

--- a/serve.json
+++ b/serve.json
@@ -9,6 +9,24 @@
           "value": "public, max-age=0, must-revalidate"
         }
       ]
+    },
+    {
+      "source": "{**/*.js,**/*.css}",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "{misc/*.js, sw.js}",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
+        }
+      ]
     }
   ],
   "trailingSlash": false,


### PR DESCRIPTION
Following Gatsby's [recommended configuration](https://www.gatsbyjs.com/docs/caching/):

- HTML `cache-control: public, max-age=0, must-revalidate`
- app-data.json `cache-control: public, max-age=0, must-revalidate`
- page-data.json `cache-control: public, max-age=0, must-revalidate`
- un-cacheable files (/misc, /sw.js, /css/bootstrap.min.css) `cache-control: public, max-age=0, must-revalidate`
- other css and js `public, max-age=31536000, immutable`

@raisedadead NGINX didn't work out well for this.  I could not see a way to match against HTML files without hard-coding each path `/learn`,`/` etc. that we needed.

On the plus side, if we go this route we can dramatically simplify the NGINX config by using serve to provide headers for the fonts, too.