### PR TITLE
fix: update sass and bootstrap headers

### DIFF
--- a/serve.json
+++ b/serve.json
@@ -20,26 +20,30 @@
       ]
     },
     {
-      "source": "{misc/*.js,sw.js,css/bootstrap.min.css}",
+      "source": "{misc/*.js,sw.js}",
       "headers": [
         {
           "key": "Cache-Control",
           "value": "public, max-age=0, must-revalidate"
         }
       ]
-    }, {
-      "source": "{sass.sync.js}",
+    },
+    {
+      "source": "{js/sass.sync.js,css/bootstrap.min.css}",
       "headers": [
         {
           "key": "Cache-Control",
-          "value": "public, max-age=172800, immutable"
+          "value": "public, max-age=3600, stale-while-revalidate=172800, must-revalidate"
         }
       ]
     }
   ],
   "trailingSlash": false,
   "rewrites": [
-    { "source": "/certification/**", "destination": "/certification/index.html" }
+    {
+      "source": "/certification/**",
+      "destination": "/certification/index.html"
+    }
   ],
   "redirects": [
     {


### PR DESCRIPTION
The combination of stale-while-revalidate and must-revalidate means that
browsers will keep using their cache until either
max-age + stale-while-revalidate has passed OR max-age has passed and
revalidation fails.

Without must-revalidate, the browser is allowed to re-use the cache
while it fetches the updated version, but that is undesirable in our
case because our users would have to reload the page twice to get
new resources.

@raisedadead I figured a max age of 1 hour was reasonably safe. It means there's a bit of lag, but the origin server will get far fewer requests.  And we basically never update either bootstrap or sass.
