### PR TITLE
feat: prevent caching of python-input-sw.js

### DIFF
--- a/serve.json
+++ b/serve.json
@@ -20,7 +20,7 @@
       ]
     },
     {
-      "source": "{misc/*.js,sw.js}",
+      "source": "{misc/*.js,sw.js,python-input-sw.js}",
       "headers": [
         {
           "key": "Cache-Control",


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Ref: https://github.com/freeCodeCamp/freeCodeCamp/issues/52536 

For context, I didn't want to clash with Gatsby's sw.js (in principle it shouldn't, but I didn't want to risk it), so I created a new service worker file to handle input and cancellation requests for the python worker. Ref: https://github.com/freeCodeCamp/freeCodeCamp/pull/52526 and https://github.com/freeCodeCamp/freeCodeCamp/pull/52587

<!-- Feel free to add any additional description of changes below this line -->
