### PR TITLE
feat: add redirect for renamed prime number sum calculator lab

### DIFF
--- a/serve.json
+++ b/serve.json
@@ -449,6 +449,10 @@
     {
       "source": "/learn/full-stack-developer/lecture-html-fundamentals/what-is-the-role-of-open-graph-tags",
       "destination": "/learn/full-stack-developer/lecture-understanding-how-html-affects-seo/what-is-the-role-of-open-graph-tags"
+    },
+    {
+      "source": "/learn/full-stack-developer/lab-sum-all-primes-calculator/build-a-sum-all-primes-calculator",
+      "destination": "/learn/full-stack-developer/lab-prime-number-sum-calculator/build-a-prime-number-sum-calculator"
     }
   ]
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

- Redirects old lab URL /learn/full-stack-developer/lab-sum-all-primes-calculator/build-a-sum-all-primes-calculator
- To new lab URL /learn/full-stack-developer/lab-prime-number-sum-calculator/build-a-prime-number-sum-calculator
